### PR TITLE
Implements "Feature Request: Set TTL on keys when saved into Redis"

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ er.dispatch(r)
 ## Env vars used
 `EVENTREPORTER_QUEUE_NAME` (redis key)
 `UA_ID` (GA UA ID)
+`EVENTREPORTER_TTL` (int, expire time)
 
 ## Testing
 ```

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ er.dispatch(r)
 ## Env vars used
 `EVENTREPORTER_QUEUE_NAME` (redis key)
 `UA_ID` (GA UA ID)
-`EVENTREPORTER_TTL` (int, expire time)
+`EVENTREPORTER_TTL` (int: controls whether to set expire time for redis keys)
 
 ## Testing
 ```

--- a/event_reporter/classes.py
+++ b/event_reporter/classes.py
@@ -8,6 +8,7 @@ import google_measurement_protocol  # event, pageview, report
 
 LOG = logging.getLogger("EventReporter")
 
+TTL = os.getenv('EVENTREPORTER_TTL') # event reporter TTL set in env
 
 class EventReporter(object):
     def __init__(self, conn, UA=None, queue_name=None):
@@ -38,6 +39,9 @@ class EventReporter(object):
     def write_event(self, event):
         ''' write event to queue '''
         self.conn.rpush(self.queue_name, json.dumps(event))
+        ''' set TTL for key '''
+        if TTL:
+            self.conn.expire(self.queue_name, int(TTL))
 
     def fetch(self):
         ''' fetch and remove most recent event from the queue '''

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+google_measurement_protocol
+mockredispy


### PR DESCRIPTION
Implementation of the suggested feature. Setting a TTL is optional, if it is not set, it defaults to the default redis behavior of keys live forever, otherwise, it is set to a user defined value in seconds. 

I have updated the documentation to reflect this change, as well as included a req.txt for ease of testing.

Closes https://github.com/e271828-/event-reporter/issues/1